### PR TITLE
Remove unnecessary code

### DIFF
--- a/src/stylus/_vendor/grider.styl
+++ b/src/stylus/_vendor/grider.styl
@@ -83,9 +83,7 @@ $container
   padding: grider-config-padding-container
 
 column(x, grider-config-columns = grider-config-columns)
-  display: inline
   float: left
-  overflow: hidden
   padding: 0 grider-config-padding-column
   width: total-width * ((((grider-config-column-width ) * x) - grider-config-gutter) / grider-config-container)
   margin: 0 total-width * ( (grider-config-gutter * 0.5) / grider-config-container)
@@ -102,8 +100,6 @@ offset(offset = 1)
 for index in (1..grider-config-columns)
   $grider-{index}
     column(index)
-    @media phone
-      column(12)
 
 @media tablet-phone
   for index in (1..grider-config-columns) 


### PR DESCRIPTION
- overflow and display properties is not necessary because the columns are floating
- The @media generates dirty code
